### PR TITLE
Import node modules explicitly declaring they are modules from node

### DIFF
--- a/src/auth/oauthFlow.ts
+++ b/src/auth/oauthFlow.ts
@@ -1,6 +1,6 @@
 import * as client from 'openid-client'
-import { createServer } from 'http'
-import { exec } from 'child_process'
+import { createServer } from 'node:http'
+import { exec } from 'node:child_process'
 import { config } from './oidc.js'
 import { scope } from '../env.js'
 import { saveTokens } from '../tokenStore.js'

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,5 +1,5 @@
-import { fileURLToPath } from 'url'
-import { dirname, join } from 'path'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)

--- a/src/tokenStore.ts
+++ b/src/tokenStore.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { TOKEN_FILE } from './paths.js'
 
 export interface StoredTokens {


### PR DESCRIPTION
Starting from nodejs 14, we can use the `node:` prefix when importing modules provided by nodejs itself.

This is useful because:

1. developers clearly see that a module is from nodejs
2. the transpiler may not be confused by modules provided both by nodejs and installed by npm