### PR TITLE
feature: High-level page content tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,17 @@ For example:
 
 You can find a list of all available endpoints in [Concrete CMS REST API - Endpoints](https://documentation.concretecms.org/9-x/developers/rest-api/concrete-cms-rest-api-endpoints)
 
+### High-level page tools
+
+In addition to OpenAPI-generated tools, the server exposes helpers for common page workflows:
+
+- `get_page_content` — read a page as a document (`html`, `html_raw`, and plain `text`) via `includes=content`
+- `update_page_content` — create an editable page version, remap block IDs, then update specific blocks (PUT page + PUT area)
+
+Prefer these when reviewing or editing page copy. Use the raw OpenAPI tools (`getPageById`, `updateBlockInPageArea`, etc.) for lower-level control.
+
+Required OAuth scopes for the update helper: `pages:read`, `pages:update`, `pages:areas:update_blocks`.
+
 ## ToDos
 
 - Test with other MCP clients.

--- a/docs/mcp-client-guide.md
+++ b/docs/mcp-client-guide.md
@@ -416,7 +416,7 @@ If the server uses `MCP_API_KEYS` with a user-bound key (`{"my-key": 42}`), the 
 | HTTP 400 | Missing `X-Concrete-User-Id` | Send CMS user ID header |
 | HTTP 409 | OAuth already in progress | Show wait message; do not start another flow |
 | `authenticated: false` | User has not OAuth'd | Start OAuth flow |
-| OAuth callback 400 | Stale MCP `dist/`, modified authorize URL, or MCP restarted mid-flow | Rebuild MCP server; forward `/oauth/start` `Location` unchanged — see [Remote MCP Server Guide](remote-server.md#proxied-oauth-backend-clients) |
+| OAuth callback 400 | Stale MCP `dist/`, modified authorize URL, MCP restarted mid-flow, or expired session | Rebuild MCP server; forward `/oauth/start` `Location` unchanged; retry within 10 minutes — see [Remote MCP Server Guide](remote-server.md#proxied-oauth-backend-clients) |
 | Tool error / CMS 401 | Token expired or revoked | Re-authorize via `/oauth/start` |
 | HTTP 404 from proxy | Missing reverse proxy route | See [Remote MCP Server Guide](remote-server.md) |
 

--- a/docs/mcp-client-guide.md
+++ b/docs/mcp-client-guide.md
@@ -18,6 +18,7 @@ When running in remote mode (`TRANSPORT_TYPE=http`), the server exposes:
 - **Streamable HTTP** MCP endpoint at `/mcp` ([MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports))
 - **Per-user OAuth** admin routes (`/oauth/start`, `/oauth/status`, `/oauth/revoke`)
 - **Tools** derived from the Concrete CMS OpenAPI spec (`openapi.yml`) — pages, files, users, system info, and more
+- **High-level page tools** — `get_page_content` (document HTML/text) and `update_page_content` (PUT page then PUT area with block-ID remapping)
 - **CMS API execution** using each user's OAuth token; permissions follow that user's CMS scopes
 
 Your application owns the conversation loop. The MCP server owns CMS token storage and tool execution.
@@ -255,7 +256,7 @@ Send as a separate request (no `id` field):
 }
 ```
 
-Tool names correspond to OpenAPI operations (e.g. `get-system-info`, `get-pages`, `get-account`). Use `tools/list` to discover the exact names and input schemas for your server's `openapi.yml`.
+Tool names correspond to OpenAPI operations (e.g. `get-system-info`, `get-pages`, `get-account`) plus high-level helpers (`get_page_content`, `update_page_content`). Prefer the high-level page tools when reading or editing page copy; use raw OpenAPI tools for lower-level control. Use `tools/list` to discover the exact names and input schemas for your server's `openapi.yml`.
 
 ## Backend agent service
 

--- a/docs/remote-server.md
+++ b/docs/remote-server.md
@@ -172,6 +172,23 @@ curl -s -D - -o /dev/null -H "Authorization: Bearer $MCP_API_KEY" \
 
 You can also run `npm run verify:oauth` to confirm the shipped `dist/` uses state-based session binding.
 
+**OAuth debug mode** (recommended while troubleshooting callback failures):
+
+```bash
+OAUTH_DEBUG=1 npm run start
+```
+
+When enabled, the browser callback page shows a `Reason:` code and details. The MCP server always logs the same reason to stderr, for example:
+
+| Reason | Meaning |
+|--------|---------|
+| `no_pending_sessions` | MCP has no in-memory OAuth session (server restarted, flow expired, or `/oauth/start` never reached this process) |
+| `pkce_match_failed` | Callback arrived, but token exchange failed for every pending session — see per-session errors in logs |
+| `user_id_mismatch` | Token exchange succeeded, but the CMS account that approved OAuth is not the `user_id` from `/oauth/start` |
+| `resolve_cms_user_failed` | Token exchange succeeded, but `/ccm/api/1.0/account` could not be read with the new access token |
+| `oauth_provider_error` | CMS redirected with `error=` instead of `code=` |
+| `missing_authorization_code` | Callback reached MCP without a `code` query parameter |
+
 ### 6. Connect your AI agent
 
 Point your agent or MCP client at the local server:
@@ -201,9 +218,9 @@ Authorize the CMS user via `/oauth/start` before calling tools. Poll `/oauth/sta
 | Broken multiline command | Missing `\` at end of a line | Every continued line except the last must end with `\` |
 | OAuth redirect mismatch | `PUBLIC_BASE_URL` differs from registered URI | Register `http://127.0.0.1:3000/oauth/callback` in CMS and match `PUBLIC_BASE_URL` |
 | Port already in use | Another process on port 3000 | Change `HTTP_PORT` and update `PUBLIC_BASE_URL` accordingly |
-| OAuth callback **400** — Invalid or expired OAuth session | Stale `dist/` (authorize URL missing `state`) or MCP restarted mid-flow | Run `npm run build`, restart **one** MCP process, verify `/oauth/start` `Location` includes `state=` |
+| OAuth callback **400** — Authorization could not be completed | See MCP server logs for `OAuth callback failed: <reason>` | Restart with `OAUTH_DEBUG=1` to show the reason in the browser |
 | Authorize URL missing `state` | Running outdated `dist/` | `npm run build && npm run verify:oauth`, then restart |
-| Callback 400 with `state` present | Client modified MCP `Location` URL, or multiple MCP processes | Forward `Location` unchanged; `lsof -nP -iTCP:3000 -sTCP:LISTEN` |
+| Callback 400 with `state` present | Client modified MCP `Location` URL, multiple MCP processes, or expired session | Forward `Location` unchanged; `lsof -nP -iTCP:3000 -sTCP:LISTEN`; complete flow within 10 minutes |
 | `/oauth/start` 409 | Concurrent OAuth for same user | Wait or call `/oauth/revoke` |
 
 ## Concrete CMS OAuth setup
@@ -256,10 +273,12 @@ sequenceDiagram
 1. **Backend** calls `GET /oauth/start?user_id=N` with `Authorization: Bearer <MCP_API_KEY>`.
 2. MCP returns **`302`** with `Location:` pointing to the CMS authorize URL. The URL includes **`state=`**, **`code_challenge=`**, `client_id`, and `redirect_uri`.
 3. Backend redirects the **browser** to that `Location` URL **unchanged** (do not rebuild or strip query parameters).
-4. User approves on Concrete CMS. CMS echoes the same `state` on callback.
-5. Browser hits `{PUBLIC_BASE_URL}/oauth/callback?code=...&state=...`. MCP looks up the in-memory session by `state` and exchanges the code.
+4. User approves on Concrete CMS. CMS redirects to `{PUBLIC_BASE_URL}/oauth/callback?code=...&state=...`.
+5. Browser hits the MCP callback. MCP resolves the pending PKCE session (by callback `state` when echoed, otherwise by trying each pending session until PKCE verification succeeds — Concrete CMS currently **replaces** `state` on callback rather than echoing the value from step 2) and exchanges the code.
 
-The browser does **not** need an MCP-host cookie. Session binding uses standard OAuth `state`, not `Set-Cookie`.
+The browser does **not** need an MCP-host cookie. Session binding uses PKCE plus an in-memory pending session, not `Set-Cookie`.
+
+> **Concrete CMS `state` behavior:** The authorize URL from `/oauth/start` includes MCP-generated `state`, but Concrete CMS may issue a **different** `state` on callback. The MCP server handles this by matching the authorization code to the correct pending session through PKCE verification. Concurrent OAuth flows remain safe because only the session whose `code_verifier` matches the issued code can complete token exchange.
 
 > **Important:** `npm run start` runs `dist/index.js`. After editing `src/`, run `npm run build` (or rely on the `prestart` hook) so `dist/` matches `src/`. A stale `dist/` build that omits `state` from authorize URLs will cause callback **400 Invalid or expired OAuth session** for proxied clients.
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node dist/index.js",
     "watch": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "test": "npm run build && node --test dist/tools/*.test.js",
     "verify:oauth": "npm run build && node scripts/verify-oauth-session.mjs",
     "verify:security": "npm run build && node scripts/verify-security.mjs",
     "cleanup:tokens": "npm run build && node scripts/cleanup-tokens.mjs",

--- a/scripts/verify-oauth-session.mjs
+++ b/scripts/verify-oauth-session.mjs
@@ -40,9 +40,12 @@ for (const [key, value] of Object.entries(baseEnv())) {
 
 console.log('OAuth session binding tests')
 
-const { createOAuthSession, consumeOAuthSession } = await import(
-  `file://${join(projectRoot, 'dist/auth/oauthSession.js')}?t=${Date.now()}`
-)
+const {
+  createOAuthSession,
+  getOAuthSession,
+  listPendingOAuthSessions,
+  removeOAuthSession,
+} = await import(`file://${join(projectRoot, 'dist/auth/oauthSession.js')}?t=${Date.now()}`)
 
 const { state, authorizationUrl } = await createOAuthSession(
   'http://127.0.0.1:3000/oauth/callback',
@@ -65,10 +68,29 @@ assert(
   'authorize URL includes PKCE code_challenge'
 )
 
-const session = consumeOAuthSession(state)
-assert(session?.codeVerifier !== undefined, 'consumeOAuthSession(state) returns PKCE session')
-assert(consumeOAuthSession(state) === null, 'session is single-use after consume')
-assert(consumeOAuthSession('wrong-state') === null, 'unknown state returns null')
+assert(getOAuthSession(state)?.codeVerifier !== undefined, 'getOAuthSession(state) returns PKCE session')
+assert(listPendingOAuthSessions().length === 1, 'one pending session is listed')
+
+const { state: state2 } = await createOAuthSession(
+  'http://127.0.0.1:3000/oauth/callback',
+  'account:read',
+  43,
+  '43'
+)
+
+assert(listPendingOAuthSessions().length === 2, 'multiple concurrent pending sessions are retained')
+assert(
+  getOAuthSession('cms-replaced-state-value') === undefined,
+  'unknown callback state does not consume pending sessions'
+)
+assert(listPendingOAuthSessions().length === 2, 'pending sessions remain after unknown state lookup')
+
+removeOAuthSession(state)
+assert(getOAuthSession(state) === undefined, 'removeOAuthSession deletes only the targeted session')
+assert(listPendingOAuthSessions().length === 1, 'other pending sessions remain after targeted removal')
+
+removeOAuthSession(state2)
+assert(listPendingOAuthSessions().length === 0, 'all pending sessions can be removed individually')
 
 console.log('Shipped dist guardrails')
 
@@ -90,6 +112,14 @@ assert(
 assert(
   oauthHandlersSource.includes("searchParams.get('state')"),
   'dist/oauthHandlers.js reads state from callback query'
+)
+assert(
+  oauthHandlersSource.includes('logOAuthCallbackFailure'),
+  'dist/oauthHandlers.js logs structured OAuth callback failure reasons'
+)
+assert(
+  !oauthHandlersSource.includes('pending-fallback'),
+  'dist/oauthHandlers.js does not use newest-session fallback'
 )
 assert(
   !oauthHandlersSource.includes('Set-Cookie'),

--- a/src/auth/oauthDebug.ts
+++ b/src/auth/oauthDebug.ts
@@ -1,0 +1,89 @@
+import { oauthDebug } from '../env.js'
+
+export type OAuthCallbackFailureReason =
+  | 'oauth_provider_error'
+  | 'missing_authorization_code'
+  | 'no_pending_sessions'
+  | 'pkce_match_failed'
+  | 'user_id_mismatch'
+  | 'resolve_cms_user_failed'
+  | 'token_persistence_failed'
+  | 'post_exchange_failed'
+
+export interface OAuthCallbackFailure {
+  reason: OAuthCallbackFailureReason
+  message: string
+  detail?: string
+  context?: Record<string, unknown>
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+export function describeOAuthError(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Unknown error'
+  }
+
+  const parts = [error.message]
+  const cause = (error as Error & { cause?: unknown }).cause
+  if (cause instanceof Error && cause.message && cause.message !== error.message) {
+    parts.push(`cause: ${cause.message}`)
+  }
+
+  const oauthError = (error as Error & { error?: string }).error
+  if (typeof oauthError === 'string' && oauthError.length > 0) {
+    parts.push(`oauth_error: ${oauthError}`)
+  }
+
+  const oauthDescription = (error as Error & { error_description?: string }).error_description
+  if (typeof oauthDescription === 'string' && oauthDescription.length > 0) {
+    parts.push(`oauth_error_description: ${oauthDescription}`)
+  }
+
+  return parts.join(' | ')
+}
+
+export function logOAuthCallbackEvent(message: string, context?: Record<string, unknown>): void {
+  if (!context || Object.keys(context).length === 0) {
+    console.error(`[concretecms-mcp] ${message}`)
+    return
+  }
+
+  console.error(`[concretecms-mcp] ${message} ${JSON.stringify(context)}`)
+}
+
+export function logOAuthCallbackFailure(failure: OAuthCallbackFailure): void {
+  logOAuthCallbackEvent(`OAuth callback failed: ${failure.reason}`, {
+    message: failure.message,
+    ...(failure.detail ? { detail: failure.detail } : {}),
+    ...(failure.context ?? {}),
+  })
+}
+
+export function formatOAuthFailureHtmlBody(failure: OAuthCallbackFailure): string {
+  const lines = [
+    `<h1>Authorization Failed</h1>`,
+    `<p>${escapeHtml(failure.message)}</p>`,
+  ]
+
+  if (oauthDebug) {
+    lines.push(`<p><strong>Reason:</strong> <code>${escapeHtml(failure.reason)}</code></p>`)
+    if (failure.detail) {
+      lines.push(`<pre>${escapeHtml(failure.detail)}</pre>`)
+    }
+    if (failure.context && Object.keys(failure.context).length > 0) {
+      lines.push(`<pre>${escapeHtml(JSON.stringify(failure.context, null, 2))}</pre>`)
+    }
+    lines.push(
+      '<p><em>Server logs contain the same reason. Set <code>OAUTH_DEBUG=0</code> to hide this detail in the browser.</em></p>'
+    )
+  }
+
+  return lines.join('\n')
+}

--- a/src/auth/oauthHandlers.ts
+++ b/src/auth/oauthHandlers.ts
@@ -13,7 +13,15 @@ import {
 import { clearTokens } from '../tokenStore.js'
 import { MultiUserAuthProvider } from './MultiUserAuthProvider.js'
 import { acquireOAuthStartLock, releaseOAuthStartLock } from './authCoordinator.js'
-import { consumeOAuthSession, createOAuthSession } from './oauthSession.js'
+import type { OAuthSession } from './oauthSession.js'
+import { getOAuthSession, listPendingOAuthSessions, removeOAuthSession, createOAuthSession } from './oauthSession.js'
+import {
+  describeOAuthError,
+  formatOAuthFailureHtmlBody,
+  logOAuthCallbackEvent,
+  logOAuthCallbackFailure,
+  type OAuthCallbackFailure,
+} from './oauthDebug.js'
 import { exchangeAuthorizationCode, saveTokensForUser } from './oauthTokens.js'
 import { parseOAuthUserId, validateOAuthApiKey } from '../server/authMiddleware.js'
 import { sendJson, blockFurtherResponseWrites } from '../server/httpResponse.js'
@@ -35,6 +43,32 @@ function isOriginAllowed(req: IncomingMessage): boolean {
     return originUrl.origin === publicUrl.origin
   } catch {
     return false
+  }
+}
+
+function sendOAuthFailure(res: ServerResponse, failure: OAuthCallbackFailure): void {
+  logOAuthCallbackFailure(failure)
+  sendHtml(res, 400, 'Authorization Failed', formatOAuthFailureHtmlBody(failure))
+}
+
+function classifyPostExchangeError(error: unknown): OAuthCallbackFailure {
+  const detail = describeOAuthError(error)
+  const message = detail.includes('does not match intended user')
+    ? 'The CMS account that approved OAuth does not match the requested user.'
+    : detail.includes('Failed to resolve CMS user')
+      ? 'OAuth succeeded, but the MCP server could not resolve the CMS user from the access token.'
+      : 'OAuth succeeded, but the MCP server could not save the tokens.'
+
+  const reason = detail.includes('does not match intended user')
+    ? 'user_id_mismatch'
+    : detail.includes('Failed to resolve CMS user')
+      ? 'resolve_cms_user_failed'
+      : 'token_persistence_failed'
+
+  return {
+    reason,
+    message,
+    detail,
   }
 }
 
@@ -163,25 +197,133 @@ async function handleOAuthCallback(
 
   const callbackUrl = new URL(req.url!, publicBaseUrl)
   const state = callbackUrl.searchParams.get('state')
-  const session = consumeOAuthSession(state)
+  const code = callbackUrl.searchParams.get('code')
+  const oauthError = callbackUrl.searchParams.get('error')
+  const oauthErrorDescription = callbackUrl.searchParams.get('error_description')
+  const pendingSessions = listPendingOAuthSessions()
 
-  if (!session) {
-    sendHtml(
-      res,
-      400,
-      'Authorization Failed',
-      '<h1>Authorization Failed</h1><p>Invalid or expired OAuth session. Please try again.</p>'
-    )
+  logOAuthCallbackEvent('OAuth callback received', {
+    hasCode: Boolean(code),
+    hasState: Boolean(state),
+    pendingSessionCount: pendingSessions.length,
+    pendingUserIds: pendingSessions.map(({ session }) => session.intendedUserId ?? session.lockUserId),
+    oauthError: oauthError ?? undefined,
+  })
+
+  if (oauthError) {
+    sendOAuthFailure(res, {
+      reason: 'oauth_provider_error',
+      message: 'Concrete CMS rejected the OAuth request before the MCP server could finish authorization.',
+      detail: oauthErrorDescription ?? oauthError,
+      context: {
+        error: oauthError,
+        error_description: oauthErrorDescription ?? undefined,
+      },
+    })
     return
   }
 
+  if (!code) {
+    sendOAuthFailure(res, {
+      reason: 'missing_authorization_code',
+      message: 'The OAuth callback did not include an authorization code.',
+      context: {
+        hasState: Boolean(state),
+        pendingSessionCount: pendingSessions.length,
+      },
+    })
+    return
+  }
+
+  const candidates: Array<{ stateKey: string; session: OAuthSession }> = []
+  if (state) {
+    const session = getOAuthSession(state)
+    if (session) {
+      candidates.push({ stateKey: state, session })
+      logOAuthCallbackEvent('OAuth callback matched pending session by state')
+    }
+  }
+
+  if (candidates.length === 0) {
+    candidates.push(...pendingSessions)
+    if (candidates.length > 0) {
+      logOAuthCallbackEvent('OAuth callback will probe pending sessions via PKCE', {
+        pendingSessionCount: candidates.length,
+        callbackStatePrefix: state ? `${state.slice(0, 8)}...` : undefined,
+      })
+    }
+  }
+
+  if (candidates.length === 0) {
+    sendOAuthFailure(res, {
+      reason: 'no_pending_sessions',
+      message: 'No pending OAuth session was found for this callback.',
+      detail:
+        'Start OAuth again from /oauth/start and complete it within 10 minutes without restarting the MCP server.',
+      context: {
+        hasState: Boolean(state),
+        callbackStatePrefix: state ? `${state.slice(0, 8)}...` : undefined,
+      },
+    })
+    return
+  }
+
+  let matched: (typeof candidates)[number] | null = null
+  let tokens: Awaited<ReturnType<typeof exchangeAuthorizationCode>> | null = null
+  const exchangeFailures: Array<{
+    stateKeyPrefix: string
+    intendedUserId?: number
+    lockUserId: string
+    error: string
+  }> = []
+
+  for (const candidate of candidates) {
+    try {
+      tokens = await exchangeAuthorizationCode(callbackUrl, candidate.session.codeVerifier, state)
+      matched = candidate
+      break
+    } catch (error) {
+      exchangeFailures.push({
+        stateKeyPrefix: `${candidate.stateKey.slice(0, 8)}...`,
+        intendedUserId: candidate.session.intendedUserId,
+        lockUserId: candidate.session.lockUserId,
+        error: describeOAuthError(error),
+      })
+    }
+  }
+
+  if (!matched || !tokens) {
+    sendOAuthFailure(res, {
+      reason: 'pkce_match_failed',
+      message: 'The authorization code could not be matched to a pending OAuth session.',
+      detail: exchangeFailures.map((failure) => JSON.stringify(failure)).join('\n'),
+      context: {
+        candidateCount: candidates.length,
+        exchangeFailures,
+      },
+    })
+    return
+  }
+
+  if (state && matched.stateKey !== state) {
+    logOAuthCallbackEvent('OAuth session resolved via PKCE match (CMS replaced callback state)', {
+      matchedStateKeyPrefix: `${matched.stateKey.slice(0, 8)}...`,
+      callbackStatePrefix: `${state.slice(0, 8)}...`,
+      intendedUserId: matched.session.intendedUserId,
+    })
+  }
+
+  removeOAuthSession(matched.stateKey)
+
   try {
-    console.error('[concretecms-mcp] Processing OAuth callback')
-    const tokens = await exchangeAuthorizationCode(callbackUrl, session.codeVerifier, state)
+    logOAuthCallbackEvent('OAuth code exchange succeeded; saving tokens', {
+      intendedUserId: matched.session.intendedUserId,
+      lockUserId: matched.session.lockUserId,
+    })
     const { userId, stored } = await saveTokensForUser(
       tokens,
-      session.parameters,
-      session.intendedUserId
+      matched.session.parameters,
+      matched.session.intendedUserId
     )
 
     authProvider.getSessionForUser(userId).applyTokens(stored)
@@ -193,15 +335,9 @@ async function handleOAuthCallback(
       `<h1>Authorization Successful!</h1><p>User ${userId} is now authorized. You can close this window and return to the application.</p>`
     )
   } catch (error) {
-    console.error(`[concretecms-mcp] Token exchange failed: ${redactError(error)}`)
-    sendHtml(
-      res,
-      400,
-      'Authorization Failed',
-      '<h1>Authorization Failed</h1><p>Authorization could not be completed. Please try again.</p>'
-    )
+    sendOAuthFailure(res, classifyPostExchangeError(error))
   } finally {
-    releaseOAuthStartLock(session.lockUserId)
+    releaseOAuthStartLock(matched.session.lockUserId)
   }
 }
 

--- a/src/auth/oauthSession.ts
+++ b/src/auth/oauthSession.ts
@@ -57,18 +57,16 @@ export async function createOAuthSession(
   }
 }
 
-export function consumeOAuthSession(state: string | null): OAuthSession | null {
-  if (!state) {
-    return null
-  }
-
+export function getOAuthSession(state: string): OAuthSession | undefined {
   cleanupExpiredSessions()
+  return sessions.get(state)
+}
 
-  const session = sessions.get(state)
-  if (!session) {
-    return null
-  }
+export function listPendingOAuthSessions(): Array<{ stateKey: string; session: OAuthSession }> {
+  cleanupExpiredSessions()
+  return [...sessions.entries()].map(([stateKey, session]) => ({ stateKey, session }))
+}
 
-  sessions.delete(state)
-  return session
+export function removeOAuthSession(stateKey: string): boolean {
+  return sessions.delete(stateKey)
 }

--- a/src/cms/apiClient.ts
+++ b/src/cms/apiClient.ts
@@ -1,0 +1,75 @@
+import type { AuthProvider } from '@ivotoby/openapi-mcp-server'
+import { canonical_url } from '../env.js'
+
+export class CmsApiError extends Error {
+  readonly status: number
+  readonly body: string
+
+  constructor(status: number, body: string, method: string, path: string) {
+    super(`CMS API ${method} ${path} failed (${status}): ${body}`)
+    this.name = 'CmsApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+export class CmsApiClient {
+  constructor(private readonly authProvider: AuthProvider) {}
+
+  async get<T = unknown>(path: string, query?: Record<string, string | undefined>): Promise<T> {
+    const url = this.buildUrl(path, query)
+    return this.request<T>('GET', url)
+  }
+
+  async put<T = unknown>(path: string, body: unknown = {}): Promise<T> {
+    const url = this.buildUrl(path)
+    return this.request<T>('PUT', url, body)
+  }
+
+  private buildUrl(path: string, query?: Record<string, string | undefined>): URL {
+    const base = canonical_url.replace(/\/$/, '')
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`
+    const url = new URL(`${base}${normalizedPath}`)
+
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, value)
+        }
+      }
+    }
+
+    return url
+  }
+
+  private async request<T>(method: string, url: URL, body?: unknown): Promise<T> {
+    const authHeaders = await this.authProvider.getAuthHeaders()
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      ...authHeaders,
+    }
+
+    const init: RequestInit = { method, headers }
+    if (body !== undefined && method !== 'GET') {
+      headers['Content-Type'] = 'application/json'
+      init.body = JSON.stringify(body)
+    }
+
+    const response = await fetch(url, init)
+    const text = await response.text()
+
+    if (!response.ok) {
+      throw new CmsApiError(response.status, text.slice(0, 2000), method, url.pathname)
+    }
+
+    if (!text) {
+      return undefined as T
+    }
+
+    try {
+      return JSON.parse(text) as T
+    } catch {
+      throw new Error(`CMS API ${method} ${url.pathname} returned non-JSON response`)
+    }
+  }
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -115,6 +115,17 @@ export const mcpApiKeys = parseMcpApiKeys()
 
 export const tokenEncryptionKey = process.env.TOKEN_ENCRYPTION_KEY ?? null
 
+export const oauthDebug = (() => {
+  const value = process.env.OAUTH_DEBUG
+  if (value === '1' || value === 'true') {
+    return true
+  }
+  if (value === '0' || value === 'false') {
+    return false
+  }
+  return false
+})()
+
 let stdioEncryptionWarningShown = false
 
 export function getTokenEncryptionKey(): string | null {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { MultiUserAuthProvider } from './auth/MultiUserAuthProvider.js'
-import { oauthStartPath, transportType, warnStdioEncryptionOnce } from './env.js'
+import { oauthStartPath, oauthDebug, transportType, warnStdioEncryptionOnce } from './env.js'
 import { startMcpServer } from './server/mcp.js'
 import { createSharedHttpServer } from './server/http.js'
 import { cleanupExpiredTokens, migrateLegacyTokens } from './tokenStore.js'
@@ -24,6 +24,9 @@ async function startHttpServer(authProvider: MultiUserAuthProvider): Promise<voi
   await startMcpServer(authProvider, { transport: 'http', httpServer })
 
   console.error(`[concretecms-mcp] Remote MCP server ready. Authorize users via ${oauthStartPath}`)
+  if (oauthDebug) {
+    console.error('[concretecms-mcp] OAUTH_DEBUG=1 — callback failures will include reason details in the browser')
+  }
 }
 
 export async function main(): Promise<void> {

--- a/src/server/mcp.ts
+++ b/src/server/mcp.ts
@@ -15,6 +15,7 @@ import {
   transportType,
 } from '../env.js'
 import { OPENAPI_SPEC_FILE } from '../paths.js'
+import { createPageTools } from '../tools/pageTools.js'
 
 export interface McpServerOptions {
   transport?: 'stdio' | 'http'
@@ -41,6 +42,7 @@ export async function startMcpServer(
     toolsMode: 'all' as const,
     disableAbbreviation: true,
     authProvider,
+    extraTools: createPageTools(authProvider),
   }
 
   const openApiServer = new OpenAPIServer(openApiServerConfig)

--- a/src/tools/htmlToText.test.ts
+++ b/src/tools/htmlToText.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { htmlToText } from './htmlToText.js'
+
+describe('htmlToText', () => {
+  it('strips tags and returns plain text', () => {
+    assert.equal(htmlToText('<p>Hello <strong>world</strong></p>'), 'Hello world')
+  })
+
+  it('decodes common entities', () => {
+    assert.equal(htmlToText('<p>A &amp; B &lt; C</p>'), 'A & B < C')
+  })
+
+  it('inserts newlines for block elements', () => {
+    assert.equal(htmlToText('<p>One</p><p>Two</p>'), 'One\nTwo')
+  })
+
+  it('returns empty string for empty input', () => {
+    assert.equal(htmlToText(''), '')
+  })
+})

--- a/src/tools/htmlToText.ts
+++ b/src/tools/htmlToText.ts
@@ -1,0 +1,51 @@
+const ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+}
+
+/**
+ * Convert HTML to plain text for reading/summarizing.
+ * Strips tags, decodes common entities, and normalizes whitespace.
+ */
+export function htmlToText(html: string): string {
+  if (!html) {
+    return ''
+  }
+
+  let text = html
+    .replace(/<\s*br\s*\/?>/gi, '\n')
+    .replace(/<\/\s*(p|div|h[1-6]|li|tr|section|article|header|footer)\s*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (_, entity: string) => decodeEntity(entity))
+
+  text = text
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim()
+
+  return text
+}
+
+function decodeEntity(entity: string): string {
+  const lower = entity.toLowerCase()
+  if (ENTITY_MAP[lower]) {
+    return ENTITY_MAP[lower]
+  }
+
+  if (lower.startsWith('#x')) {
+    const code = Number.parseInt(lower.slice(2), 16)
+    return Number.isFinite(code) ? String.fromCodePoint(code) : `&${entity};`
+  }
+
+  if (lower.startsWith('#')) {
+    const code = Number.parseInt(lower.slice(1), 10)
+    return Number.isFinite(code) ? String.fromCodePoint(code) : `&${entity};`
+  }
+
+  return `&${entity};`
+}

--- a/src/tools/pageTools.ts
+++ b/src/tools/pageTools.ts
@@ -1,0 +1,283 @@
+import type { AuthProvider, ExtraToolDefinition } from '@ivotoby/openapi-mcp-server'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { CmsApiClient, CmsApiError } from '../cms/apiClient.js'
+import { htmlToText } from './htmlToText.js'
+import {
+  BlockRemapError,
+  remapBlockIds,
+  type BlockUpdateRequest,
+  type PageArea,
+} from './remapBlockIds.js'
+
+interface PageContentResponse {
+  id?: number
+  path?: string
+  name?: string
+  description?: string
+  version?: unknown
+  content?: {
+    content?: string
+    raw?: string
+  }
+  areas?: PageArea[]
+}
+
+interface BlockUpdateResult {
+  areaHandle: string
+  oldBlockID: number
+  newBlockID: number
+  ok: boolean
+  error?: string
+}
+
+function jsonResult(data: unknown): CallToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  }
+}
+
+function errorResult(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: message }],
+  }
+}
+
+function requirePageId(args: Record<string, unknown>): number {
+  const pageID = args.pageID
+  if (typeof pageID !== 'number' || !Number.isInteger(pageID) || pageID <= 0) {
+    throw new Error('pageID must be a positive integer')
+  }
+  return pageID
+}
+
+function parseBlockUpdates(args: Record<string, unknown>): BlockUpdateRequest[] {
+  const blocks = args.blocks
+  if (!Array.isArray(blocks) || blocks.length === 0) {
+    throw new Error('blocks must be a non-empty array')
+  }
+
+  return blocks.map((block, index) => {
+    if (!block || typeof block !== 'object') {
+      throw new Error(`blocks[${index}] must be an object`)
+    }
+
+    const item = block as Record<string, unknown>
+    const areaHandle = item.areaHandle
+    const blockID = item.blockID
+    const value = item.value
+
+    if (typeof areaHandle !== 'string' || !areaHandle) {
+      throw new Error(`blocks[${index}].areaHandle must be a non-empty string`)
+    }
+    if (typeof blockID !== 'number' || !Number.isInteger(blockID) || blockID <= 0) {
+      throw new Error(`blocks[${index}].blockID must be a positive integer`)
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(`blocks[${index}].value must be an object`)
+    }
+
+    return {
+      areaHandle,
+      blockID,
+      value: value as Record<string, unknown>,
+    }
+  })
+}
+
+async function handleGetPageContent(
+  client: CmsApiClient,
+  args: Record<string, unknown>
+): Promise<CallToolResult> {
+  try {
+    const pageID = requirePageId(args)
+    const version =
+      args.version === 'recent' || args.version === 'active' ? args.version : 'active'
+
+    const page = await client.get<PageContentResponse>(`/ccm/api/1.0/pages/${pageID}`, {
+      includes: 'content',
+      version,
+    })
+
+    const html = page.content?.content ?? ''
+    const htmlRaw = page.content?.raw ?? ''
+
+    return jsonResult({
+      id: page.id,
+      path: page.path,
+      name: page.name,
+      description: page.description,
+      version: page.version,
+      html,
+      html_raw: htmlRaw,
+      text: htmlToText(html),
+    })
+  } catch (error) {
+    return errorResult(formatToolError(error))
+  }
+}
+
+async function handleUpdatePageContent(
+  client: CmsApiClient,
+  args: Record<string, unknown>
+): Promise<CallToolResult> {
+  try {
+    const pageID = requirePageId(args)
+    const updates = parseBlockUpdates(args)
+    const pageBody =
+      args.page && typeof args.page === 'object' && !Array.isArray(args.page)
+        ? (args.page as Record<string, unknown>)
+        : {}
+
+    const beforePage = await client.get<PageContentResponse>(`/ccm/api/1.0/pages/${pageID}`, {
+      includes: 'areas',
+      version: 'recent',
+    })
+
+    await client.put(`/ccm/api/1.0/pages/${pageID}`, pageBody)
+
+    const afterPage = await client.get<PageContentResponse>(`/ccm/api/1.0/pages/${pageID}`, {
+      includes: 'areas',
+      version: 'recent',
+    })
+
+    const remapped = remapBlockIds(
+      beforePage.areas ?? [],
+      afterPage.areas ?? [],
+      updates
+    )
+
+    const blockResults: BlockUpdateResult[] = []
+
+    for (const update of remapped) {
+      try {
+        await client.put(
+          `/ccm/api/1.0/pages/${pageID}/${encodeURIComponent(update.areaHandle)}/${update.newBlockID}`,
+          { value: update.value }
+        )
+        blockResults.push({
+          areaHandle: update.areaHandle,
+          oldBlockID: update.oldBlockID,
+          newBlockID: update.newBlockID,
+          ok: true,
+        })
+      } catch (error) {
+        blockResults.push({
+          areaHandle: update.areaHandle,
+          oldBlockID: update.oldBlockID,
+          newBlockID: update.newBlockID,
+          ok: false,
+          error: formatToolError(error),
+        })
+      }
+    }
+
+    return jsonResult({
+      id: afterPage.id ?? pageID,
+      path: afterPage.path,
+      name: afterPage.name,
+      description: afterPage.description,
+      version: afterPage.version,
+      blocks: blockResults,
+      note: 'Page version was not auto-approved. Use updatePageVersionByPageIdAndVersionId to approve if needed.',
+    })
+  } catch (error) {
+    return errorResult(formatToolError(error))
+  }
+}
+
+function formatToolError(error: unknown): string {
+  if (error instanceof CmsApiError || error instanceof BlockRemapError) {
+    return error.message
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  return String(error)
+}
+
+export function createPageTools(authProvider: AuthProvider): ExtraToolDefinition[] {
+  const client = new CmsApiClient(authProvider)
+
+  return [
+    {
+      id: 'get_page_content',
+      tool: {
+        name: 'get_page_content',
+        description:
+          'Review a Concrete CMS page as a document. Returns sanitized HTML, raw HTML, and plain text. Prefer this over getPageById with includes=content when summarizing or reading page copy. Does not return areas/blocks.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pageID: {
+              type: 'number',
+              description: 'ID of the page to read',
+            },
+            version: {
+              type: 'string',
+              enum: ['active', 'recent'],
+              description: 'Page version to read. Defaults to active.',
+            },
+          },
+          required: ['pageID'],
+        },
+      },
+      handler: (args) => handleGetPageContent(client, args),
+    },
+    {
+      id: 'update_page_content',
+      tool: {
+        name: 'update_page_content',
+        description:
+          'Update page block content safely. Creates a new editable page version (PUT page), remaps block IDs, then updates each block (PUT area). Provide blockID values from the version you inspected. Does not approve the new version.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            pageID: {
+              type: 'number',
+              description: 'ID of the page to update',
+            },
+            page: {
+              type: 'object',
+              description:
+                'Optional page metadata for the PUT page step (name, description, type, template, attributes). Send empty/omit to only create a version.',
+              properties: {
+                name: { type: 'string' },
+                description: { type: 'string' },
+                type: { type: 'string' },
+                template: { type: 'string' },
+                attributes: { type: 'object' },
+              },
+            },
+            blocks: {
+              type: 'array',
+              description:
+                'Blocks to update. blockID must match the layout before this call; the tool remaps IDs after creating a new version.',
+              items: {
+                type: 'object',
+                properties: {
+                  areaHandle: {
+                    type: 'string',
+                    description: 'Area name (handle) containing the block',
+                  },
+                  blockID: {
+                    type: 'number',
+                    description: 'Block ID from the inspected page version',
+                  },
+                  value: {
+                    type: 'object',
+                    description:
+                      'Block edit payload (same shape as the Concrete block editing form / UpdatedBlock.value)',
+                  },
+                },
+                required: ['areaHandle', 'blockID', 'value'],
+              },
+            },
+          },
+          required: ['pageID', 'blocks'],
+        },
+      },
+      handler: (args) => handleUpdatePageContent(client, args),
+    },
+  ]
+}

--- a/src/tools/remapBlockIds.test.ts
+++ b/src/tools/remapBlockIds.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { BlockRemapError, remapBlockIds } from './remapBlockIds.js'
+
+describe('remapBlockIds', () => {
+  const beforeAreas = [
+    {
+      name: 'Main',
+      blocks: [
+        { id: 10, type: 'content' },
+        { id: 11, type: 'html' },
+      ],
+    },
+    {
+      name: 'Sidebar',
+      blocks: [{ id: 20, type: 'content' }],
+    },
+  ]
+
+  const afterAreas = [
+    {
+      name: 'Main',
+      blocks: [
+        { id: 110, type: 'content' },
+        { id: 111, type: 'html' },
+      ],
+    },
+    {
+      name: 'Sidebar',
+      blocks: [{ id: 120, type: 'content' }],
+    },
+  ]
+
+  it('remaps by area handle and index', () => {
+    const result = remapBlockIds(beforeAreas, afterAreas, [
+      { areaHandle: 'Main', blockID: 11, value: { content: 'updated' } },
+      { areaHandle: 'Sidebar', blockID: 20, value: { content: 'side' } },
+    ])
+
+    assert.deepEqual(result, [
+      {
+        areaHandle: 'Main',
+        oldBlockID: 11,
+        newBlockID: 111,
+        value: { content: 'updated' },
+      },
+      {
+        areaHandle: 'Sidebar',
+        oldBlockID: 20,
+        newBlockID: 120,
+        value: { content: 'side' },
+      },
+    ])
+  })
+
+  it('throws when the old block ID is unknown', () => {
+    assert.throws(
+      () =>
+        remapBlockIds(beforeAreas, afterAreas, [
+          { areaHandle: 'Main', blockID: 999, value: {} },
+        ]),
+      BlockRemapError
+    )
+  })
+
+  it('throws when remapped block is not in the requested area', () => {
+    assert.throws(
+      () =>
+        remapBlockIds(beforeAreas, afterAreas, [
+          { areaHandle: 'Sidebar', blockID: 10, value: {} },
+        ]),
+      /not in area "Sidebar"/
+    )
+  })
+})

--- a/src/tools/remapBlockIds.ts
+++ b/src/tools/remapBlockIds.ts
@@ -1,0 +1,96 @@
+export interface AreaBlock {
+  id: number
+  type?: string
+  value?: unknown
+}
+
+export interface PageArea {
+  name: string
+  blocks?: AreaBlock[]
+}
+
+export interface BlockUpdateRequest {
+  areaHandle: string
+  blockID: number
+  value: Record<string, unknown>
+}
+
+export interface RemappedBlockUpdate {
+  areaHandle: string
+  oldBlockID: number
+  newBlockID: number
+  value: Record<string, unknown>
+}
+
+export class BlockRemapError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'BlockRemapError'
+  }
+}
+
+/**
+ * Map block IDs from a pre-version-create layout to post-version-create IDs
+ * by matching area handle + index within each area.
+ */
+export function remapBlockIds(
+  beforeAreas: PageArea[],
+  afterAreas: PageArea[],
+  updates: BlockUpdateRequest[]
+): RemappedBlockUpdate[] {
+  const idMap = buildIdMap(beforeAreas, afterAreas)
+
+  return updates.map((update) => {
+    const newBlockID = idMap.get(update.blockID)
+    if (newBlockID === undefined) {
+      throw new BlockRemapError(
+        `Cannot remap block ${update.blockID} in area "${update.areaHandle}": ` +
+          'block not found in the pre-update page layout'
+      )
+    }
+
+    const afterArea = afterAreas.find((area) => area.name === update.areaHandle)
+    if (!afterArea) {
+      throw new BlockRemapError(
+        `Area "${update.areaHandle}" not found on the page after creating a new version`
+      )
+    }
+
+    const stillInArea = (afterArea.blocks ?? []).some((block) => block.id === newBlockID)
+    if (!stillInArea) {
+      throw new BlockRemapError(
+        `Remapped block ${update.blockID} → ${newBlockID} is not in area "${update.areaHandle}" ` +
+          'after creating a new version'
+      )
+    }
+
+    return {
+      areaHandle: update.areaHandle,
+      oldBlockID: update.blockID,
+      newBlockID,
+      value: update.value,
+    }
+  })
+}
+
+function buildIdMap(beforeAreas: PageArea[], afterAreas: PageArea[]): Map<number, number> {
+  const afterByName = new Map(afterAreas.map((area) => [area.name, area]))
+  const idMap = new Map<number, number>()
+
+  for (const beforeArea of beforeAreas) {
+    const afterArea = afterByName.get(beforeArea.name)
+    if (!afterArea) {
+      continue
+    }
+
+    const beforeBlocks = beforeArea.blocks ?? []
+    const afterBlocks = afterArea.blocks ?? []
+    const count = Math.min(beforeBlocks.length, afterBlocks.length)
+
+    for (let i = 0; i < count; i++) {
+      idMap.set(beforeBlocks[i].id, afterBlocks[i].id)
+    }
+  }
+
+  return idMap
+}


### PR DESCRIPTION
The server already wraps the OpenAPI spec via `src/server/mcp.ts` (`toolsMode: 'all'`). `@ivotoby/openapi-mcp-server` supports custom tools through config `extraTools` without replacing generated REST tools — keep raw tools alongside these helpers.

Concrete CMS behavior that drives the update design:

- `GET /pages/{id}?includes=content` returns document HTML (`content.content` sanitized, `content.raw` unsanitized).
- `PUT /pages/{id}` always calls `getVersionToModify()` (even with `{}`), creating an editable draft version; the Page transformer does **not** include areas unless requested, and PUT has no `includes` query.
- After version create, block IDs change. `PUT /pages/{id}/{areaHandle}/{blockID}` must use IDs from the **recent** version.
- Therefore the update tool must: PUT page → GET recent areas → remap old→new block IDs by area + index → PUT each block.