### PR TITLE
Consider empty ENV values as not set

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -7,7 +7,7 @@ function requireEnv(name: string): string {
 }
 
 function optionalEnv(name: string, defaultValue: string): string {
-  return process.env[name] ?? defaultValue
+  return process.env[name] || defaultValue
 }
 
 function optionalIntEnv(name: string, defaultValue: number): number {
@@ -77,7 +77,7 @@ export const publicBaseUrl = (() => {
     return normalizeBaseUrl(url)
   }
 
-  return normalizeBaseUrl(url ?? `http://localhost:${httpPort}`)
+  return normalizeBaseUrl(url || `http://localhost:${httpPort}`)
 })()
 
 export const oauthRedirectUri = `${publicBaseUrl}${oauthCallbackPath}`
@@ -113,7 +113,7 @@ function parseMcpApiKeys(): McpApiKeyEntry[] {
 
 export const mcpApiKeys = parseMcpApiKeys()
 
-export const tokenEncryptionKey = process.env.TOKEN_ENCRYPTION_KEY ?? null
+export const tokenEncryptionKey = process.env.TOKEN_ENCRYPTION_KEY || null
 
 export const oauthDebug = (() => {
   const value = process.env.OAUTH_DEBUG

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -7,11 +7,11 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
 export const PROJECT_ROOT = join(__dirname, '..')
-export const LEGACY_TOKEN_FILE = process.env.TOKEN_FILE ?? join(PROJECT_ROOT, '.tokens.json')
+export const LEGACY_TOKEN_FILE = process.env.TOKEN_FILE || join(PROJECT_ROOT, '.tokens.json')
 export const OPENAPI_SPEC_FILE = join(PROJECT_ROOT, 'openapi.yml')
 
 export function getTokenBaseDir(): string {
-  return process.env.TOKEN_DIR ?? join(homedir(), '.concretecms-mcp', 'tokens')
+  return process.env.TOKEN_DIR || join(homedir(), '.concretecms-mcp', 'tokens')
 }
 
 export function getSiteKey(): string {


### PR DESCRIPTION
What about considering empty env values as if they were not set?

For example, if `TOKEN_DIR` is an existing env var set to an empty string, `getTokenBaseDir()` would result an empty string.

Let's avoid that.