### PR TITLE
Tell typescript we are using node

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "types": ["node"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
With recent typescript versions, I've sometime seen that VSCode complains about node stuff not defined.

What about telling typescript the project is executed by node?