### PR TITLE
Allow using Concrete via HTTP instead of HTTPS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,7 @@ MCP_API_KEY=
 
 # Optional: use when hosting on the same domain as Concrete CMS
 # PATH_PREFIX=/ccm-mcp
+
+# Optional: allow a Concrete server exposed over plain HTTP (local/dev only).
+# openid-client v6 otherwise refuses non-HTTPS URLs. Never enable in production.
+# CONCRETE_ALLOW_INSECURE_HTTP=true

--- a/manifest.json
+++ b/manifest.json
@@ -43,7 +43,8 @@
         "OAUTH_STATUS_PATH": "${user_config.OAUTH_STATUS_PATH}",
         "OAUTH_REVOKE_PATH": "${user_config.OAUTH_REVOKE_PATH}",
         "HEALTH_PATH": "${user_config.HEALTH_PATH}",
-        "OAUTH_DEBUG": "${user_config.OAUTH_DEBUG}"
+        "OAUTH_DEBUG": "${user_config.OAUTH_DEBUG}",
+        "CONCRETE_ALLOW_INSECURE_HTTP": "${user_config.CONCRETE_ALLOW_INSECURE_HTTP}"
       }
     }
   },
@@ -198,6 +199,13 @@
       "type": "boolean",
       "title": "OAuth debug mode",
       "description": "Enable debug logging for OAuth flows (default: false)",
+      "required": false,
+      "sensitive": false
+    },
+    "CONCRETE_ALLOW_INSECURE_HTTP": {
+      "type": "boolean",
+      "title": "Allow insecure HTTP",
+      "description": "Allow connecting to a Concrete server over plain HTTP instead of HTTPS. For local/development instances only - never enable against a production server (default: false)",
       "required": false,
       "sensitive": false
     }

--- a/src/auth/oidc.ts
+++ b/src/auth/oidc.ts
@@ -1,5 +1,5 @@
 import * as client from 'openid-client'
-import { canonical_url, client_id, client_secret } from '../env.js'
+import { allowInsecureHttp, canonical_url, client_id, client_secret } from '../env.js'
 
 export const server: client.ServerMetadata = {
   issuer: canonical_url,
@@ -12,3 +12,10 @@ export const config: client.Configuration = new client.Configuration(
   client_id,
   client_secret
 )
+
+// openid-client v6 refuses non-HTTPS requests (OAUTH_HTTP_REQUEST_FORBIDDEN).
+// When explicitly opted in, relax that restriction so a Concrete server exposed
+// over plain HTTP (typically a local/dev instance) can be used.
+if (allowInsecureHttp) {
+  client.allowInsecureRequests(config)
+}

--- a/src/env.ts
+++ b/src/env.ts
@@ -24,6 +24,17 @@ function optionalIntEnv(name: string, defaultValue: number): number {
   return parsed
 }
 
+function optionalBoolEnv(name: string, defaultValue: boolean): boolean {
+  const value = process.env[name]
+  if (value === '1' || value === 'true') {
+    return true
+  }
+  if (value === '0' || value === 'false') {
+    return false
+  }
+  return defaultValue
+}
+
 export function normalizePathPrefix(prefix: string): string {
   if (!prefix || prefix === '/') {
     return ''
@@ -115,16 +126,13 @@ export const mcpApiKeys = parseMcpApiKeys()
 
 export const tokenEncryptionKey = process.env.TOKEN_ENCRYPTION_KEY || null
 
-export const oauthDebug = (() => {
-  const value = process.env.OAUTH_DEBUG
-  if (value === '1' || value === 'true') {
-    return true
-  }
-  if (value === '0' || value === 'false') {
-    return false
-  }
-  return false
-})()
+export const oauthDebug = optionalBoolEnv('OAUTH_DEBUG', false)
+
+// Allow the Concrete server to be reached over plain HTTP. openid-client v6
+// rejects non-HTTPS requests with OAUTH_HTTP_REQUEST_FORBIDDEN before OAuth
+// discovery even starts, so this must be opt-in for local/dev instances served
+// over HTTP. Never enable it against a production server.
+export const allowInsecureHttp = optionalBoolEnv('CONCRETE_ALLOW_INSECURE_HTTP', false)
 
 let stdioEncryptionWarningShown = false
 


### PR DESCRIPTION
This may be useful for local development