### PR TITLE
Normalize ConcreteCMS canonical URL

### DIFF
--- a/src/auth/resolveUser.ts
+++ b/src/auth/resolveUser.ts
@@ -29,7 +29,7 @@ function extractUserId(body: AccountResponse): number | null {
 export { extractUserId }
 
 export async function resolveCmsUserId(accessToken: string): Promise<number> {
-  const url = `${canonical_url.replace(/\/$/, '')}/ccm/api/1.0/account`
+  const url = `${canonical_url}/ccm/api/1.0/account`
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${accessToken}`,

--- a/src/cms/apiClient.ts
+++ b/src/cms/apiClient.ts
@@ -27,9 +27,8 @@ export class CmsApiClient {
   }
 
   private buildUrl(path: string, query?: Record<string, string | undefined>): URL {
-    const base = canonical_url.replace(/\/$/, '')
     const normalizedPath = path.startsWith('/') ? path : `/${path}`
-    const url = new URL(`${base}${normalizedPath}`)
+    const url = new URL(`${canonical_url}${normalizedPath}`)
 
     if (query) {
       for (const [key, value] of Object.entries(query)) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -38,7 +38,7 @@ function prefixedPath(segment: string, envName: string, pathPrefix: string): str
   return optionalEnv(envName, defaultPath)
 }
 
-export const canonical_url = requireEnv('CONCRETE_CANONICAL_URL')
+export const canonical_url = requireEnv('CONCRETE_CANONICAL_URL').replace(/\/+$/, '')
 export const client_id = requireEnv('CONCRETE_API_CLIENT_ID')
 export const client_secret = requireEnv('CONCRETE_API_CLIENT_SECRET')
 export const scope = requireEnv('CONCRETE_API_SCOPE')


### PR DESCRIPTION
If users specify a canonical URL with a trailing slash, the authorization fails because the issuer doesn't match the `iss` claim emitted by Concrete

So, let's normalize the canonical URL, so that:
- we can append paths without producing double slashes
- the issuer matches the `iss` claim emitted by Concrete