### PR TITLE
Add "pack" script to create the .mcpb file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "bin": "dist/index.js",
   "scripts": {
     "build": "tsc",
+    "prepack": "npm run build",
+    "pack": "npx mcpb pack . concretecms-mcp-server.mcpb",
     "prestart": "npm run build",
     "start": "node dist/index.js",
     "watch": "tsc --watch",


### PR DESCRIPTION
We already have a manifest.json file: what about allowing users to create the .mcpb file with a simple "npm run pack"?

Of course this requires having the mcpb command installed with

```sh
npm install -g @anthropic-ai/mcpb
```