### PR TITLE
Surface the specific claim on ID token validation failures

### DIFF
--- a/src/auth/oauthTokens.ts
+++ b/src/auth/oauthTokens.ts
@@ -1,5 +1,6 @@
 import * as client from 'openid-client'
 import { config } from './oidc.js'
+import { oauthDebug } from '../env.js'
 import { saveTokens, type StoredTokens } from '../tokenStore.js'
 import { resolveCmsUserId } from './resolveUser.js'
 
@@ -7,15 +8,42 @@ export type StoredTokensWithParameters = StoredTokens & {
   parameters: Record<string, string>
 }
 
+// openid-client wraps oauth4webapi's error as `cause` with the opaque message
+// "unexpected JWT claim value encountered". The real detail (which claim, the
+// expected vs actual value) lives one level deeper. Surface it so ID token
+// validation failures are actionable instead of a dead end.
+function enrichTokenError(error: unknown): Error {
+  const wrapper = error as { message?: string; cause?: unknown }
+  const inner = wrapper?.cause as { message?: string; cause?: unknown } | undefined
+  const detail = inner?.cause as
+    | { claim?: string; expected?: unknown; claims?: Record<string, unknown> }
+    | undefined
+
+  if (detail?.claim) {
+    const actual = detail.claims?.[detail.claim]
+    let message = `${inner?.message ?? wrapper?.message} [claim="${detail.claim}", expected=${JSON.stringify(detail.expected)}, actual=${JSON.stringify(actual)}]`
+    if (oauthDebug && detail.claims) {
+      message += ` id_token_claims=${JSON.stringify(detail.claims)}`
+    }
+    return new Error(message)
+  }
+
+  return error instanceof Error ? error : new Error(String(error))
+}
+
 export async function exchangeAuthorizationCode(
   callbackUrl: URL,
   codeVerifier: string,
   expectedState?: string | null
 ): Promise<client.TokenEndpointResponse> {
-  return client.authorizationCodeGrant(config, callbackUrl, {
-    pkceCodeVerifier: codeVerifier,
-    ...(expectedState ? { expectedState } : {}),
-  })
+  try {
+    return await client.authorizationCodeGrant(config, callbackUrl, {
+      pkceCodeVerifier: codeVerifier,
+      ...(expectedState ? { expectedState } : {}),
+    })
+  } catch (error) {
+    throw enrichTokenError(error)
+  }
 }
 
 export async function saveTokensForUser(


### PR DESCRIPTION
openid-client reports ID token claim mismatches with the opaque message "unexpected JWT claim value encountered", hiding which claim failed and its expected/actual values one level down in the error cause chain.

Wrap the authorization code exchange to unwrap that detail and rethrow an actionable error, including the full decoded claims when `OAUTH_DEBUG` is on.